### PR TITLE
Feat/mongo support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ types.js.map
 logs/
 **/*.log
 .env
+data/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,65 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+### [0.1.0] - 2023-04-13
+
+### Feat
+
+- feat: added support to mongodb provider
+- added global log as singleton
+- added category atribute to step
+- added mask option to stackLog middleware
+
+#### Now Its possible create an unique instance of log globally using
+
+```ts
+
+import { GlobalLog } from 'ts-logs';
+
+const global = GlobalLog.singleton();
+
+// ...
+// remember clear steps after publish or write local
+global.clear();
+
+```
+
+#### Now Its possible publish log to mongodb
+
+The operation is updateOne with `upsert=true` based on `log.uid` and `log.name`.
+If already exists some log them update else insert
+
+```ts
+
+await log.publish(Config.Mongo({ url: 'mongodb://localhost:27017' }));
+
+```
+
+#### Now you can categorize the step
+
+Based on your business rule Its possible define a category to a step
+
+```ts
+
+Step.info({ name: 'some', message: 'info', category: 'financial' });
+
+```
+
+#### Now Its possible add mask to stackLog
+
+The middleware stackLog accept mask config
+
+```ts
+
+stackLog({
+    writeLocal: true,
+    mask: [ { key: 'password' } ]
+})
+
+```
+
+---
+
 ### [0.0.18] - 2023-04-13
 
 ### Feat

--- a/README.md
+++ b/README.md
@@ -72,31 +72,49 @@ $ yarn add ts-logs
 ---
 ## Documentation
 
-sdk in beta version.
-
 Example
 
 ```ts
 import { Log, Step } from 'ts-logs';
 
 // create a global log
-const global = Log.init({ name: 'First Log', origin: 'https://global.com' });
+const log = Log.init({ name: 'First Log', origin: 'https://global.com' });
 
 // create steps
 const info = Step.info({ message: 'Fetching api...', name: 'Request Login', method: 'POST' });
 const error = Step.error({ message: 'Timeout', name: 'Login', stack: 'Error stack' });
 
 // add steps to global log
-global.addSteps([ info, error ]);
+log.addSteps([ info, error ]);
 
 // print or save logs
-global.print();
-global.writeLocal();
-global.publish(config);
+log.print();
+await log.writeLocal();
+await log.publish(config);
 
 ```
 
 ---
+
+### Use a Singleton Instance Globally
+
+You can use a global log to publish once on finish all process
+
+```ts
+
+import { GlobalLog, Config } from 'ts-logs';
+
+const global = GlobalLog.singleton();
+
+// ...
+
+global.addStep(step);
+
+// ...
+
+await global.publish(Config.Mongo({ url: 'mongodb://localhost:27017' }));
+
+```
 
 ### Create step from catch block
 
@@ -114,7 +132,7 @@ class DoSomething {
         } catch(error) {
 
             // create step instance from error
-            return Step.catch(error);
+            global.addStep(Step.catch(error));
         }
     }
 }
@@ -139,6 +157,7 @@ Example generated log. The log is a json object with array of step object
   "steps": [
     {
       "name": "Find Item",
+      "category": "none",
       "tags": ["item", "product", "card"],
       "url": "https://my-app.com/products/1",
       "stack": "none",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+
+services:
+  mongo:
+    container_name: logs
+    image: mongo:4.4-focal
+    volumes: 
+      - ./data:/data/db
+    ports:
+      - 27017:27017
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: mongo
+      MONGO_INITDB_ROOT_PASSWORD: mongo
+volumes: 
+  data:

--- a/lib/core/mongo-provider.ts
+++ b/lib/core/mongo-provider.ts
@@ -1,0 +1,18 @@
+import * as mongo from 'mongodb';
+import { LProps, Logs, MongoConfig, Provider, SavePayload } from "../types";
+import { GetFolderName } from '../utils';
+
+const MongoProvider: Provider<MongoConfig> = ({
+    async save(config: MongoConfig, log: Readonly<Logs>): Promise<SavePayload> {
+        const client = new mongo.MongoClient(config.url, config.options);
+        const collectionName = GetFolderName(log.name);
+        await client.connect();
+        await client.db('logs')
+            .collection<LProps>(collectionName)
+            .updateOne({ uid: log.uid, name: log.name }, { $set: { ...log } }, { upsert: true });
+        await client.close();
+        return { statusCode: 200, url: log.uid };
+    }
+});
+
+export default MongoProvider;

--- a/lib/core/providers.ts
+++ b/lib/core/providers.ts
@@ -1,8 +1,9 @@
-import { S3Config, HttpConfig } from "../types";
+import { S3Config, HttpConfig, MongoConfig } from "../types";
 
 export const Config = ({
     S3: (config: S3Config ): S3Config => config,
-    Http: (config: HttpConfig): HttpConfig => { new URL(config.url); return config }
+    Http: (config: HttpConfig): HttpConfig => { new URL(config.url); return config; },
+    Mongo: (config: MongoConfig): MongoConfig => { config.type = 'mongodb'; return config; }
 });
 
 export default Config;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,5 +1,6 @@
 import { AxiosError, RawAxiosRequestHeaders, Axios } from "axios";
 import { NextFunction, Request, Response } from "express";
+import { MongoClientOptions } from "mongodb";
 
 export type Type = "error" | "info" | "warn" | "debug" | "fatal" | "stack";
 export type Locale = Intl.LocalesArgument;
@@ -135,6 +136,7 @@ export interface Steps extends SProps {
 }
 
 export interface Logs extends LProps {
+    setId(uid: string):Readonly<Logs> | Logs;
     setName(name: string): Readonly<Logs> | Logs;
     setIp(ip: string): Readonly<Logs> | Logs;
     setOrigin(url: string): Readonly<Logs> | Logs;
@@ -147,7 +149,7 @@ export interface Logs extends LProps {
     hasSteps(): boolean;
     clone(stateType: LogStateType): Readonly<Logs> | Logs;
     rmLogs(days: number, dirname?: string): Promise<void>;
-    clearSteps(): Readonly<Logs> | Logs;
+    clear(): Readonly<Logs> | Logs;
 }
 
 export type BuildStepMessages = (step: Steps, locales?: Locale, options?: LocalOpt) => string;
@@ -202,6 +204,12 @@ export interface HttpConfig {
 export interface S3Credentials {
     accessKeyId: string;
     secretAccessKey: string;
+}
+
+export interface MongoConfig {
+    url: string;
+    type?: 'mongodb';
+    options?: MongoClientOptions;
 }
 
 export type AWSRegions = 'us-east-2' |

--- a/log.example.json
+++ b/log.example.json
@@ -4,22 +4,20 @@
     "ip": "127.0.0.1",
     "origin": "https://my-domain.com.br",
     "createdAt": "2022-01-21T07:01:5300Z",
+    "stateType": "stateful",
     "steps": [
         {
             "uid": "e0de0bcd-d25c-4d26-9ee6-80bc59317abb",
             "name": "login",
-            "tags": [
-                "request",
-                "post",
-                "login"
-            ],
+            "tags": [ "request", "post", "login" ],
             "url": "https://app2.domain.com.br/user",
             "stack": "invalid data app.js:201:54",
-            "data": "{ email: 'ac@gmail.com', password: '*******' }",
+            "data": { "email": "ac@gmail.com", "password": "*******" },
             "statusCode": 401,
             "message": "invalid password",
             "type": "error | info | warn | debug | fatal | trace",
-            "createdAt": "2022-01-21T07:01:5300Z"
+            "createdAt": "2022-01-21T07:01:5300Z",
+            "category": "none"
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ts-logs",
 	"description": "This package provide a skd for audit and manager logs in nodejs and express",
-	"version": "0.0.18",
+	"version": "0.1.0",
 	"main": "index.js",
 	"types": "index.d.ts",
 	"author": "Alessandro Dev",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
 	],
 	"dependencies": {
 		"@aws-sdk/client-s3": "^3.312.0",
-		"axios": "^1.3.2"
+		"axios": "^1.3.2",
+		"mongodb": "^5.2.0"
 	}
 }

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -24,4 +24,12 @@ describe('config', () => {
 
         expect(Config.S3(config)).toEqual(config);
     });
+
+    it('should create mongo config', () => {
+        const config = Config.Mongo({ url: 'mongodb://localhost:27017' });
+        expect(config).toEqual({
+            "type": "mongodb",
+            "url": "mongodb://localhost:27017",
+        });
+    });
 });

--- a/tests/log.e2e.ts
+++ b/tests/log.e2e.ts
@@ -2,60 +2,94 @@ import { S3Credentials, SavePayload } from "../lib/types";
 import { Log } from "../lib/core/log";
 import { Config } from "../lib/core/providers";
 import { Step } from "../lib/core/step";
+import { GlobalLog } from "../lib/core/global-log";
 const accessKeyId = process.env.ACCESS_KEY_ID!;
 const bucketName = process.env.BUCKET_NAME!;
 const region = process.env.REGION! as any;
 const secretAccessKey = process.env.SECRET_ACCESS_KEY!;
 
-it('should publish to http', async () => {
-    jest.setTimeout(900000);
-    const data = { echo: 'hello', info: { some: 'info' } };
-    const step = Step.info({ name: 'Test', message: 'testing...', data });
-    const log = Log.init({ name: 'Test', steps: [step] });
-    const url = 'https://postback-4dev.onrender.com/test-log';
-    const config = Config.Http({ url });
-    const result = await log.publish(config);
-    console.log(result?.url);
-    expect(result).toEqual({ statusCode: 200, url } satisfies SavePayload);
-});
+describe('integration test', () => {
 
-it('should publish to s3', async () => {
-    jest.setTimeout(900000);
+    describe('http', () => {
+        it('should publish to http', async () => {
+            jest.setTimeout(900000);
+            const data = { echo: 'hello', info: { some: 'info' } };
+            const step = Step.info({ name: 'Test', message: 'testing...', data });
+            const log = Log.init({ name: 'Test', steps: [step] });
+            const url = 'https://postback-4dev.onrender.com/test-log';
+            const config = Config.Http({ url });
+            const result = await log.publish(config);
+            console.log(result?.url);
+            expect(result).toEqual({ statusCode: 200, url } satisfies SavePayload);
+        });
+    });
 
-    expect(accessKeyId).toBeDefined()
-    expect(bucketName).toBeDefined()
-    expect(region).toBeDefined()
-    expect(secretAccessKey).toBeDefined()
+    describe('s3', () => {
+        it('should publish to s3', async () => {
+            jest.setTimeout(900000);
 
-    const credentials = { accessKeyId, secretAccessKey } satisfies S3Credentials;
-    const config = Config.S3({ bucketName, credentials, region });
-    const step = Step.info({ name: 'Test', message: 'testing...', data: 'hello world' });
+            expect(accessKeyId).toBeDefined()
+            expect(bucketName).toBeDefined()
+            expect(region).toBeDefined()
+            expect(secretAccessKey).toBeDefined()
 
-    const log = Log.init({ name: 'Test', steps: [step] });
-    const result = await log.publish(config);
+            const credentials = { accessKeyId, secretAccessKey } satisfies S3Credentials;
+            const config = Config.S3({ bucketName, credentials, region });
+            const step = Step.info({ name: 'Test', message: 'testing...', data: 'hello world' });
 
-    console.log(result?.url);
-    expect(result?.statusCode).toBe(200);
-    expect(result?.url).toBeDefined();
-});
+            const log = Log.init({ name: 'Test', steps: [step] });
+            const result = await log.publish(config);
 
-it('should publish to s3', async () => {
-    jest.setTimeout(900000);
+            console.log(result?.url);
+            expect(result?.statusCode).toBe(200);
+            expect(result?.url).toBeDefined();
+        });
 
-    expect(accessKeyId).toBeDefined()
-    expect(bucketName).toBeDefined()
-    expect(region).toBeDefined()
-    expect(secretAccessKey).toBeDefined()
-    const data = { echo: 'hello', info: { some: 'info' } };
+        it('should publish to s3', async () => {
+            jest.setTimeout(900000);
 
-    const credentials = { accessKeyId, secretAccessKey } satisfies S3Credentials;
-    const config = Config.S3({ bucketName, credentials, region });
-    const step = Step.info({ name: 'Test', message: 'testing...', data });
+            expect(accessKeyId).toBeDefined()
+            expect(bucketName).toBeDefined()
+            expect(region).toBeDefined()
+            expect(secretAccessKey).toBeDefined()
+            const data = { echo: 'hello', info: { some: 'info' } };
 
-    const log = Log.init({ name: 'Test', steps: [step] });
-    const result = await log.publish(config);
+            const credentials = { accessKeyId, secretAccessKey } satisfies S3Credentials;
+            const config = Config.S3({ bucketName, credentials, region });
+            const step = Step.info({ name: 'Test', message: 'testing...', data });
 
-    console.log(result?.url);
-    expect(result?.statusCode).toBe(200);
-    expect(result?.url).toBeDefined();
+            const log = Log.init({ name: 'Test', steps: [step] });
+            const result = await log.publish(config);
+
+            console.log(result?.url);
+            expect(result?.statusCode).toBe(200);
+            expect(result?.url).toBeDefined();
+        });
+    });
+
+    describe("mongo", () => {
+        it('should save log in local database', async () => {
+            jest.setTimeout(900000);
+            const log = GlobalLog.singleton({ name: 'test-log' });
+            log.addStep(Step.create({}));
+
+            const result = await log.publish(Config.Mongo({ url: 'mongodb://mongo:mongo@localhost:27017' }));
+            console.log(result);
+
+            expect(result?.statusCode).toBe(200);
+            expect(result?.url).toBe(log.uid);
+        });
+
+        it('should update log and add step', async () => {
+            jest.setTimeout(900000);
+            const log = GlobalLog.singleton({ name: 'test-log' });
+            log.addStep(Step.create({}));
+
+            const result = await log.publish(Config.Mongo({ url: 'mongodb://mongo:mongo@localhost:27017' }));
+            console.log(result);
+
+            expect(result?.statusCode).toBe(200);
+            expect(result?.url).toBe(log.uid);
+        });
+    });
 });

--- a/tests/log.spec.ts
+++ b/tests/log.spec.ts
@@ -1,5 +1,5 @@
 import { LProps } from "../lib/types";
-import { Log, Step } from "../lib/core";
+import { GlobalLog, Log, Step } from "../lib/core";
 import { join } from "node:path";
 import { readdirSync } from "node:fs";
 
@@ -227,19 +227,40 @@ describe('log', () => {
 
         expect(log.steps).toHaveLength(2);
 
-        log.clearSteps();
+        log.clear();
         expect(log.steps).toHaveLength(0);
     });
 
-    
+    it('should clear and generate a new id to global log', () => {
+        const log = GlobalLog.singleton();
+        const originalId = log.uid;
+        log.clear();
+        expect(log.uid).not.toBe(originalId);
+    })
+
     it('should clear all steps from copy and keep original log immutable', () => {
         const step = Step.info({ message: 'message', name: 'info' });
         const log = Log.init({ name: 'log', stateType: 'stateless', steps:[ step, step ] });
 
         expect(log.steps).toHaveLength(2);
 
-        const copy = log.clearSteps();
+        const copy = log.clear();
         expect(log.steps).toHaveLength(2);
         expect(copy.steps).toHaveLength(0);
+    });
+
+    it('should change log state (id) with success', () => {
+        const log = Log.init({ name: 'log' });
+        const newId = 'new-uuid-set';
+        log.setId(newId);
+        expect(log.uid).toBe(newId);
+    });
+
+    it('should do not change id if stateless', () => {
+        const log = Log.init({ name: 'log', stateType: 'stateless', uid: 'original-id' });
+        const newId = 'new-uuid-set';
+        const newLog = log.setId(newId);
+        expect(newLog.uid).toBe(newId);
+        expect(log.uid).toBe('original-id');
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1716,6 +1716,19 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
+"@types/webidl-conversions@*":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz#2b8e60e33906459219aa587e9d1a612ae994cfe7"
+  integrity sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog==
+
+"@types/whatwg-url@^8.2.1":
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/@types/whatwg-url/-/whatwg-url-8.2.2.tgz#749d5b3873e845897ada99be4448041d4cc39e63"
+  integrity sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==
+  dependencies:
+    "@types/node" "*"
+    "@types/webidl-conversions" "*"
+
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
@@ -2009,6 +2022,11 @@ bser@2.1.1:
   integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
   dependencies:
     node-int64 "^0.4.0"
+
+bson@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-5.2.0.tgz#c81d35dd30e2798203e5422a639780ea98dd25ba"
+  integrity sha512-HevkSpDbpUfsrHWmWiAsNavANKYIErV2ePXllp1bwq5CDreAaFVj6RVlZpJnxK4WWDCJ/5jMUpaY6G526q3Hjg==
 
 buffer-from@^1.0.0:
   version "1.1.2"
@@ -2811,6 +2829,11 @@ ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
+ip@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.0.tgz#4cf4ab182fee2314c75ede1276f8c80b479936da"
+  integrity sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -3443,6 +3466,11 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
+memory-pager@^1.0.2:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/memory-pager/-/memory-pager-1.5.0.tgz#d8751655d22d384682741c972f2c3d6dfa3e66b5"
+  integrity sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -3528,6 +3556,25 @@ module-lookup-amd@^7.0.1:
     glob "^7.1.6"
     requirejs "^2.3.5"
     requirejs-config-file "^4.0.0"
+
+mongodb-connection-string-url@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz#57901bf352372abdde812c81be47b75c6b2ec5cf"
+  integrity sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==
+  dependencies:
+    "@types/whatwg-url" "^8.2.1"
+    whatwg-url "^11.0.0"
+
+mongodb@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-5.2.0.tgz#58c3688614e793a8e970d797255130db9fd6ddea"
+  integrity sha512-nLgo95eP1acvjBcOdrUV3aqpWwHZCZwhYA2opB8StybbtQL/WoE5pk92qUUfjbKOWcGLYJczTqQbfOQhYtrkKg==
+  dependencies:
+    bson "^5.2.0"
+    mongodb-connection-string-url "^2.6.0"
+    socks "^2.7.1"
+  optionalDependencies:
+    saslprep "^1.0.3"
 
 ms@2.1.2:
   version "2.1.2"
@@ -3820,6 +3867,11 @@ proxy-from-env@^1.1.0:
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
+punycode@^2.1.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
+  integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
+
 pure-rand@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.0.1.tgz#31207dddd15d43f299fdcdb2f572df65030c19af"
@@ -3940,6 +3992,13 @@ safe-buffer@~5.2.0:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
+saslprep@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/saslprep/-/saslprep-1.0.3.tgz#4c02f946b56cf54297e347ba1093e7acac4cf226"
+  integrity sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==
+  dependencies:
+    sparse-bitfield "^3.0.3"
+
 sass-lookup@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/sass-lookup/-/sass-lookup-3.0.0.tgz#3b395fa40569738ce857bc258e04df2617c48cac"
@@ -3986,6 +4045,19 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+smart-buffer@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
+  integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
+
+socks@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.7.1.tgz#d8e651247178fde79c0663043e07240196857d55"
+  integrity sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==
+  dependencies:
+    ip "^2.0.0"
+    smart-buffer "^4.2.0"
+
 source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
@@ -4003,6 +4075,13 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+sparse-bitfield@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz#ff4ae6e68656056ba4b3e792ab3334d38273ca11"
+  integrity sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==
+  dependencies:
+    memory-pager "^1.0.2"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -4158,6 +4237,13 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tr46@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-3.0.0.tgz#555c4e297a950617e8eeddef633c87d4d9d6cbf9"
+  integrity sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==
+  dependencies:
+    punycode "^2.1.1"
+
 ts-graphviz@^1.5.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/ts-graphviz/-/ts-graphviz-1.5.2.tgz#e0e803abe9dad923fa413208720776e3084e518b"
@@ -4310,6 +4396,19 @@ wcwidth@^1.0.1:
   integrity sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==
   dependencies:
     defaults "^1.0.3"
+
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
+
+whatwg-url@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-11.0.0.tgz#0a849eebb5faf2119b901bb76fd795c2848d4018"
+  integrity sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==
+  dependencies:
+    tr46 "^3.0.0"
+    webidl-conversions "^7.0.0"
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
### [0.1.0] - 2023-04-13

### Feat

- feat: added support to mongodb provider 
- added global log as singleton #82 @santosdeva 
- added category atribute to step #82 @santosdeva 
- added mask option to stackLog middleware #82 @santosdeva 

#### Now Its possible create an unique instance of log globally using

```ts

import { GlobalLog } from 'ts-logs';

const global = GlobalLog.singleton();

// ...
// remember clear steps after publish or write local
global.clear();

```

#### Now Its possible publish log to mongodb

The operation is updateOne with `upsert=true` based on `log.uid` and `log.name`.
If already exists some log them update else insert

```ts

await log.publish(Config.Mongo({ url: 'mongodb://localhost:27017' }));

```

#### Now you can categorize the step

Based on your business rule Its possible define a category to a step

```ts

Step.info({ name: 'some', message: 'info', category: 'financial' });

```

#### Now Its possible add mask to stackLog

The middleware stackLog accept mask config

```ts

stackLog({
    writeLocal: true,
    mask: [ { key: 'password' } ]
})

```