### PR TITLE
fix: ensure new date on reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+### [0.1.3] - 2023-04-26
+
+### Fix
+
+- fix: ensure reset `createdAt` attribute for a new date on clear `GlobalLog`
+
+---
+
 ### [0.1.2] - 2023-04-24
 
 ### Feat

--- a/lib/core/log.ts
+++ b/lib/core/log.ts
@@ -36,7 +36,7 @@ export class Log implements Logs {
         this.name = props.name ?? 'default';
         this.ip = props.ip ?? 'none';
         this.origin = props.origin ?? 'none';
-        this.createdAt = new Date();
+        this.createdAt = props?.createdAt ?? new Date();
         this.stateType = stateType ?? 'stateful';
         const statefulArr = props.steps ? [...props.steps] : [];
         const statelessArr = Object.freeze(props.steps ?? []);
@@ -251,8 +251,9 @@ export class Log implements Logs {
     async publish(config: S3Config | HttpConfig | MongoConfig): Promise<SavePayload | null> {
         try {
             let result: SavePayload | null = null;
-            if (!!config?.ignoreEmpty && !(this.hasSteps())) { return result; }
-            if ((config as S3Config)?.bucketName && (config as S3Config)?.region && (config as S3Config)?.credentials) {
+            if (!!config?.ignoreEmpty && !(this.hasSteps())) { 
+                return result; 
+            } else if ((config as S3Config)?.bucketName && (config as S3Config)?.region && (config as S3Config)?.credentials) {
                 result = await S3Provider.save(config as S3Config, this);
             } else if ((config as HttpConfig)?.url && (config as MongoConfig).type !== 'mongodb') {
                 result = await HttProvider.save(config as HttpConfig, this);
@@ -294,11 +295,13 @@ export class Log implements Logs {
     clear(): Logs | Readonly<Logs> {
         const uid = randomUUID();
         if (this.stateType === 'stateful') {
+            this.createdAt = new Date();
             this.steps = [];
             this.uid = uid;
             return this;
         }
-        return new Log({ ...this, steps: [], uid });
+        const createdAt = new Date();
+        return new Log({ ...this, steps: [], uid, createdAt });
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ts-logs",
 	"description": "This package provide a skd for audit and manager logs in nodejs and express",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"main": "index.js",
 	"types": "index.d.ts",
 	"author": "Alessandro Dev",

--- a/tests/log.e2e.ts
+++ b/tests/log.e2e.ts
@@ -112,11 +112,11 @@ describe('integration test', () => {
 
         it('should publish and expires after 1 day', async () => {
             jest.setTimeout(900000);
-            const log = GlobalLog.singleton({ name: 'test-log' });
+            const log = GlobalLog.singleton({ name: 'one-day' });
             log.addStep(Step.create({ name: 'expires-in-one-day' }));
 
             const result = await log.publish(Config.Mongo({
-                url: 'mongodb://mongo:mongo@localhost:27017',
+                url: 'mongodb://mongo:mongo@localhost:27017/?authSource=admin',
                 expireAfterDays: 1
             }));
             console.log(result);

--- a/tests/log.spec.ts
+++ b/tests/log.spec.ts
@@ -95,6 +95,7 @@ describe('log', () => {
         const step = Step.info({ name: 'Info', message: 'Teste 1' });
         const log = Log.init({ name: 'Teste', steps: [step], stateType: 'stateless' });
         expect(log.steps).toHaveLength(1);
+        expect(log.hasSteps()).toBeTruthy();
         expect(Object.isFrozen(log.steps)).toBeTruthy();
 
         const newLog = log.removeStep(step.uid);
@@ -243,10 +244,12 @@ describe('log', () => {
         const log = Log.init({ name: 'log', stateType: 'stateless', steps:[ step, step ] });
 
         expect(log.steps).toHaveLength(2);
+        expect(log.hasSteps()).toBeTruthy();
 
         const copy = log.clear();
         expect(log.steps).toHaveLength(2);
         expect(copy.steps).toHaveLength(0);
+        expect(copy.hasSteps()).toBeFalsy();
     });
 
     it('should change log state (id) with success', () => {
@@ -262,5 +265,16 @@ describe('log', () => {
         const newLog = log.setId(newId);
         expect(newLog.uid).toBe(newId);
         expect(log.uid).toBe('original-id');
+    });
+
+    it('should create a new date and uid after clear', () => {
+        const log = GlobalLog.singleton();
+        const date1 = log.createdAt.getTime();
+        const uid1 = log.uid;
+        // after clear
+        const date2 = log.clear().createdAt.getTime();
+        const uid2 = log.uid;
+        expect(date1).not.toBe(date2);
+        expect(uid1).not.toBe(uid2);
     });
 });


### PR DESCRIPTION

### [0.1.3] - 2023-04-26

### Fix

- fix: ensure reset `createdAt` attribute for a new date on clear `GlobalLog`
